### PR TITLE
Add retries param

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -196,7 +196,7 @@ class API(ResourceAttributesMixin, object):
 
     resource_class = Resource
 
-    def __init__(self, base_url=None, auth=None, format=None, append_slash=True, session=None, serializer=None, timeout=None):
+    def __init__(self, base_url=None, auth=None, format=None, append_slash=True, session=None, serializer=None, timeout=None, retries=3):
         if serializer is None:
             serializer = Serializer(default=format)
 
@@ -213,6 +213,7 @@ class API(ResourceAttributesMixin, object):
             "session": session,
             "serializer": serializer,
             "timeout": timeout,
+            "retries": retries,
         }
 
         # Do some Checks for Required Values


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nuevas características**
	- Se ha añadido un parámetro `retries` al constructor de la clase `API`, permitiendo a los usuarios especificar el número de reintentos en caso de fallos en las llamadas a la API, mejorando así la robustez de las interacciones con la API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->